### PR TITLE
Use GIS::Distance instead of Geo::Distance.

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -5,7 +5,7 @@ version:      0.05
 version_from: 
 installdirs:  site
 requires:
-    Geo::Distance:                 0.06
+    GIS::Distance:                 0.14
     Geo::Proj4:                    0.96
     Math::Polygon:                 0.003
     Test::More:                    0.47

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,7 +7,7 @@ WriteMakefile
   , VERSION     => '0.99'
   , PREREQ_PM   =>
      { Test::More    => 0.47
-     , Geo::Distance => 0.06
+     , GIS::Distance => 0.14
      , Geo::Proj4    => 1.01
      , Math::Polygon => 1.01
      , Math::Trig    => 1.00

--- a/lib/Geo/Point.pm
+++ b/lib/Geo/Point.pm
@@ -9,7 +9,9 @@ use strict;
 use warnings;
 
 use Geo::Proj;
-use Carp        qw/confess croak/;
+use Math::Trig                  qw/deg2rad/;
+use GIS::Distance::Constants    qw/$KILOMETER_RHO/;
+use Carp                        qw/confess croak/;
 
 =chapter NAME
 
@@ -401,20 +403,29 @@ Always returns zero.
 
 sub perimeter() { 0 }
 
-=method distancePointPoint $geodist, $units, $point
+=method distancePointPoint $gisdist, $units, $point
 Compute the distance between the current point and some other $point in
-$units.  The $geodist object will do the calculations.  See M<distance()>.
+$units.  The $gisdist object will do the calculations.  See M<distance()>.
 =cut
 
 # When two points are within one UTM zone, this could be done much
 # easier...
 
 sub distancePointPoint($$$)
-{   my ($self, $geodist, $units, $other) = @_;
+{   my ($self, $gisdist, $units, $other) = @_;
 
     my $here  = $self->in('wgs84');
     my $there = $other->in('wgs84');
-    $geodist->distance($units, $here->latlong, $there->latlong);
+    my $distance = $gisdist->distance($here->latlong, $there->latlong);
+
+    if ($units eq 'degrees') {
+        return( ($distance->km() / $KILOMETER_RHO) * 360 );
+    }
+    elsif ($units eq 'radians') {
+        return deg2rad( ($distance->km() / $KILOMETER_RHO) * 360 );
+    }
+
+    return $distance->$units();
 }
 
 =method sameAs $other, $tolerance

--- a/lib/Geo/Shape.pm
+++ b/lib/Geo/Shape.pm
@@ -13,8 +13,7 @@ use Geo::Line       ();
 use Geo::Surface    ();
 use Geo::Space      ();
 
-use Geo::Distance   ();
-use Math::Trig      qw/deg2rad/;
+use GIS::Distance   ();
 use Carp            qw/croak confess/;
 
 =chapter NAME
@@ -160,9 +159,9 @@ Calculate the distance between this object and some other object.
 For many combinations of objects this is not supported or only
 partially supported.
 
-This calculation is performed with L<Geo::Distance> in accurate mode.
+This calculation is performed with L<GIS::Distance> in accurate mode.
 The default $unit is kilometers.  Other units are provided in the manual
-page of L<Geo::Distance>.  As extra unit, C<degrees> and C<radians> are
+page of L<GIS::Distance>.  As extra unit, C<degrees> and C<radians> are
 added as well as the C<km> alias for kilometer.
 
 =error distance calculation not implemented between a $kind and a $kind
@@ -170,25 +169,19 @@ Only a subset of all objects can be used in the distance calculation.
 The limitation is purely caused by lack of time to implement this.
 =cut
 
-my $geodist;
+my $gisdist;
 sub distance($;$)
 {   my ($self, $other, $unit) = (shift, shift, shift);
     $unit ||= 'kilometer';
 
-    unless($geodist)
-    {   $geodist = Geo::Distance->new;
-        $geodist->formula('hsin');
-        $geodist->reg_unit(1 => 'radians');
-        $geodist->reg_unit(deg2rad(1) => 'degrees');
-        $geodist->reg_unit(km => 1, 'kilometer');
-    }
+    $gisdist ||= GIS::Distance->new('Haversine');
 
     my $proj = $self->proj;
     $other = $other->in($proj)
         if $other->proj ne $proj;
 
     if($self->isa('Geo::Point') && $other->isa('Geo::Point'))
-    {   return $self->distancePointPoint($geodist, $unit, $other);
+    {   return $self->distancePointPoint($gisdist, $unit, $other);
     }
 
     die "ERROR: distance calculation not implemented between a "

--- a/t/11point.t
+++ b/t/11point.t
@@ -8,7 +8,7 @@ use warnings;
 
 use lib qw(. lib tests ../MathPolygon/lib ../../MathPolygon/lib);
 
-use Test::More tests => 43;
+use Test::More tests => 44;
 
 use Geo::Point;
 use Geo::Proj;
@@ -99,7 +99,13 @@ is_deeply([$p->bbox], [ 5,4, 5,4 ]);
 
 my $p1 = $gp->latlong(0, 1);
 my $p2 = $gp->latlong(1, 1);
-cmp_ok(abs($p1->distance($p2, 'nautical mile') - 60), '<', 0.1);
+cmp_ok(abs($p1->distance($p2, 'nautical_mile') - 60), '<', 0.1);
+
+cmp_ok(
+  $p1->distance($p2, 'degrees'),
+  '>',
+  $p1->distance($p2, 'radians'),
+);
 
 isnt($p1->distance($p2, 'degrees'), 0);
 isnt($p1->distance($p2, 'radians'), 0);


### PR DESCRIPTION
Geo::Distance is officially deprecated in favor of GIS::Distance.

This also fixes:
- A bug with the custom radians and degrees units where radians were smaller than degrees.
- `Geo::Distance->distance()` takes coordinates as long/lat pairs but they are being passed in with `Geo::Point->latlong()`, the reverse. I don't know if/how this logic ever produced correct results.  `GIS::Distance->distance()` actually **does** take the coordinates as lat/long pairs.